### PR TITLE
Sample metadata: Fix typo in packaging.yaml

### DIFF
--- a/.google/packaging.yaml
+++ b/.google/packaging.yaml
@@ -15,7 +15,7 @@ level:        INTERMEDIATE
 
 icon: screenshots/icon-web.png
 
-api_refs:
+apiRefs:
     - android:android.media.session.MediaSession
     - android:android.media.session.MediaSession.Callback
     - android:android.media.session.MediaController


### PR DESCRIPTION
Rename the api_refs field to apiRefs, in order to match the schema on the server.