### PR TITLE
Fix top activity not finished when toggles drawer

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "22.0.0"
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
         applicationId "com.example.android.uamp"

--- a/mobile/src/main/java/com/example/android/uamp/ui/ActionBarCastActivity.java
+++ b/mobile/src/main/java/com/example/android/uamp/ui/ActionBarCastActivity.java
@@ -124,6 +124,7 @@ public abstract class ActionBarCastActivity extends ActionBarActivity {
 
                 Class activityClass = mDrawerMenuContents.getActivity(position);
                 startActivity(new Intent(ActionBarCastActivity.this, activityClass), extras);
+                finish();
             }
         }
 


### PR DESCRIPTION
1. When toggles drawer item, new activity will be created and pushed to
activity stack, which makes more and more activies on the stack.
2. Update build tools version to 22.0.1