### PR TITLE
Fix Seeking while Paused Bug

### DIFF
--- a/mobile/src/main/java/com/example/android/uamp/playback/LocalPlayback.java
+++ b/mobile/src/main/java/com/example/android/uamp/playback/LocalPlayback.java
@@ -236,11 +236,8 @@ public class LocalPlayback implements Playback, AudioManager.OnAudioFocusChangeL
     @Override
     public void seekTo(int position) {
         LogHelper.d(TAG, "seekTo called with ", position);
-
-        if (mMediaPlayer == null) {
-            // If we do not have a current media player, simply update the current position
-            mCurrentPosition = position;
-        } else {
+        mCurrentPosition = position;
+        if (mMediaPlayer != null) {
             if (mMediaPlayer.isPlaying()) {
                 mState = PlaybackStateCompat.STATE_BUFFERING;
             }


### PR DESCRIPTION
To reproduce the bug:
1) Pause the player on FullScreenPlayerActivity
2) Seek to a new position
3) Start playing again
The player would start playing from the position before seeking.