### PR TITLE
Fix remove playing notification when app is swiped from recents

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-rc01'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.android.gms:strict-version-matcher-plugin:$gms_strict_version_matcher_version"
 

--- a/media/src/main/java/com/example/android/uamp/media/MusicService.kt
+++ b/media/src/main/java/com/example/android/uamp/media/MusicService.kt
@@ -278,12 +278,10 @@ class MusicService : androidx.media.MediaBrowserServiceCompat() {
 
         private fun updateNotification(state: PlaybackStateCompat) {
             val updatedState = state.state
-            if (mediaController.metadata == null) {
-                return
-            }
 
             // Skip building a notification when state is "none".
-            val notification = if (updatedState != PlaybackStateCompat.STATE_NONE) {
+            val notification = if (mediaController.metadata != null
+                    && updatedState != PlaybackStateCompat.STATE_NONE) {
                 notificationBuilder.buildNotification(mediaSession.sessionToken)
             } else {
                 null
@@ -299,12 +297,14 @@ class MusicService : androidx.media.MediaBrowserServiceCompat() {
                      * notes that "calling this method does *not* put the service in the started
                      * state itself, even though the name sounds like it."
                      */
-                    if (!isForegroundService) {
-                        startService(Intent(applicationContext, this@MusicService.javaClass))
-                        startForeground(NOW_PLAYING_NOTIFICATION, notification)
-                        isForegroundService = true
-                    } else if (notification != null) {
-                        notificationManager.notify(NOW_PLAYING_NOTIFICATION, notification)
+                    if (notification != null) {
+                        if (!isForegroundService) {
+                            startService(Intent(applicationContext, this@MusicService.javaClass))
+                            startForeground(NOW_PLAYING_NOTIFICATION, notification)
+                            isForegroundService = true
+                        } else {
+                            notificationManager.notify(NOW_PLAYING_NOTIFICATION, notification)
+                        }
                     }
                 }
                 else -> {


### PR DESCRIPTION
Fix GitHub issue #250 
When I swipe UAMP away from recents, the removeNowPlayingNotification() isn't called because in the method updateNotification() the metadata is already null if(mediaController.metadata == null) return and notification is stuck in the notification tray and control icons also does not work.