### PR TITLE
Fix remove playing notification when app is swiped from recents

### DIFF
--- a/media/src/main/java/com/example/android/uamp/media/MusicService.kt
+++ b/media/src/main/java/com/example/android/uamp/media/MusicService.kt
@@ -283,7 +283,8 @@ class MusicService : androidx.media.MediaBrowserServiceCompat() {
             }
 
             // Skip building a notification when state is "none".
-            val notification = if (updatedState != PlaybackStateCompat.STATE_NONE) {
+            val notification = if (mediaController.metadata != null
+                    && updatedState != PlaybackStateCompat.STATE_NONE) {
                 notificationBuilder.buildNotification(mediaSession.sessionToken)
             } else {
                 null
@@ -299,12 +300,14 @@ class MusicService : androidx.media.MediaBrowserServiceCompat() {
                      * notes that "calling this method does *not* put the service in the started
                      * state itself, even though the name sounds like it."
                      */
-                    if (!isForegroundService) {
-                        startService(Intent(applicationContext, this@MusicService.javaClass))
-                        startForeground(NOW_PLAYING_NOTIFICATION, notification)
-                        isForegroundService = true
-                    } else if (notification != null) {
-                        notificationManager.notify(NOW_PLAYING_NOTIFICATION, notification)
+                    if (notification != null) {
+                        if (!isForegroundService) {
+                            startService(Intent(applicationContext, this@MusicService.javaClass))
+                            startForeground(NOW_PLAYING_NOTIFICATION, notification)
+                            isForegroundService = true
+                        } else {
+                            notificationManager.notify(NOW_PLAYING_NOTIFICATION, notification)
+                        }
                     }
                 }
                 else -> {


### PR DESCRIPTION
Fix GitHub issue #250 
When I swipe UAMP away from recents, the `removeNowPlayingNotification()` isn't called because in the method `updateNotification()` the metadata is already null and this check returns without removing notification `if(mediaController.metadata == null) return ` . So because of this notification is stuck in the notification tray and control icons also does not work.